### PR TITLE
Fix warning Django 1.9

### DIFF
--- a/appconf/utils.py
+++ b/appconf/utils.py
@@ -5,7 +5,8 @@ def import_attribute(import_path, exception_handler=None):
     try:
         from importlib import import_module
     except ImportError:
-        from django.utils.importlib import import_module
+        if django.VERSION < (1, 8):
+            from django.utils.importlib import import_module
     module_name, object_name = import_path.rsplit('.', 1)
     try:
         module = import_module(module_name)


### PR DESCRIPTION
Fix the deprectaed warning for django.utils.importlib in Django 1.9