### PR TITLE
use django.utils.six instead of standalone six

### DIFF
--- a/appconf/base.py
+++ b/appconf/base.py
@@ -1,8 +1,7 @@
 import sys
 
-import six
-
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 
 from .utils import import_attribute
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license='BSD',
     url='http://django-appconf.readthedocs.org/',
     packages=['appconf'],
-    install_requires=['six'],
+    install_requires=[],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,8 @@ setenv =
     DJANGO_SETTINGS_MODULE=tests.test_settings
 deps =
     flake8
-    coverage
+	py{26,27,33,34,35,pypy}: coverage
+	py32: coverage==3.7.1 # latest coverage support py3.2
     django-discover-runner
     dj13: https://github.com/django/django/archive/stable/1.3.x.zip#egg=django
     dj14: https://github.com/django/django/archive/stable/1.4.x.zip#egg=django


### PR DESCRIPTION
this app is working in django, so no need to add additional dependency when it exist. using django.utils.six is better.