### PR TITLE
Fix Travis build for Py32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ matrix:
     - env: TOXENV=py34-dj110
     - env: TOXENV=py35-dj110
 install:
-  - pip install tox
+  # Virtualenv < 14 is required to keep the Python 3.2 builds running.
+  - pip install tox "virtualenv<14"
+
 script:
   - tox
 notifications:


### PR DESCRIPTION
Pip 8 drops Python 3 compatibility. Specifying virtualenv version should fix it. 