### PR TITLE
Pre-release changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,12 @@ sudo: false
 language: python
 env:
   - TOXENV=flake8-py27
-  - TOXENV=flake8-py33
-  - TOXENV=py26-dj14
-  - TOXENV=py27-dj14
-  - TOXENV=py27-dj17
+  - TOXENV=flake8-py34
   - TOXENV=py27-dj18
   - TOXENV=py27-dj19
   - TOXENV=py27-dj110
-  - TOXENV=py32-dj17
   - TOXENV=py32-dj18
-  - TOXENV=py33-dj17
   - TOXENV=py33-dj18
-  - TOXENV=py34-dj17
   - TOXENV=py34-dj18
   - TOXENV=py34-dj19
   - TOXENV=py34-dj110

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: TOXENV=py35-dj19
     - env: TOXENV=py27-dj110
     - env: TOXENV=py34-dj110
     - env: TOXENV=py35-dj110

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: python
+python:
+  - 3.5
 env:
   - TOXENV=flake8-py27
   - TOXENV=flake8-py34

--- a/appconf/__init__.py
+++ b/appconf/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .base import AppConf  # noqa
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/appconf/base.py
+++ b/appconf/base.py
@@ -122,11 +122,6 @@ class AppConf(six.with_metaclass(AppConfMetaClass)):
     def configured_data(self):
         return self._meta.configured_data
 
-    # For Python < 2.6:
-    @property
-    def __members__(self):
-        return self.__dir__()
-
     def __getattr__(self, name):
         if self._meta.proxy:
             return getattr(self._meta.holder, name)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.0.2 (2016-04-19)
+------------------
+
+* Minor fixes to test setup
+
+* Update supported Django and Python versions, in line with Django's
+  own supported versions.
+
+
 1.0 (2015-02-15)
 ----------------
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from .models import (AppConf, TestConf, PrefixConf,
                      YetAnotherPrefixConf, SeparateConf,
@@ -63,6 +64,18 @@ class TestConfTests(TestCase):
     def test_subclass_configured_data(self):
         self.assertTrue('TESTS_CONFIGURE_METHOD_VALUE2' in dir(settings))
         self.assertEqual(settings.TESTS_CONFIGURE_METHOD_VALUE2, False)
+
+    # Pair of tests checking override_settings compat.
+    # See:
+    #   https://github.com/django-compressor/django-appconf/issues/29
+    #   https://github.com/django-compressor/django-appconf/issues/30
+    @override_settings(TESTS_SIMPLE_VALUE=False)
+    def test_override_settings_once(self):
+        self.assertEqual(settings.TESTS_SIMPLE_VALUE, False)
+
+    @override_settings(TESTS_SIMPLE_VALUE=False)
+    def test_override_settings_twice(self):
+        self.assertEqual(settings.TESTS_SIMPLE_VALUE, False)
 
 
 class PrefixConfTests(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -52,12 +52,8 @@ class TestConfTests(TestCase):
     def test_dir_members(self):
         custom_conf = TestConf()
         self.assertTrue('TESTS_SIMPLE_VALUE' in dir(settings))
-        if hasattr(settings, '__members__'):  # django 1.5 removed __members__
-            self.assertTrue('TESTS_SIMPLE_VALUE' in settings.__members__)
         self.assertTrue('SIMPLE_VALUE' in dir(custom_conf))
-        self.assertTrue('SIMPLE_VALUE' in custom_conf.__members__)
         self.assertFalse('TESTS_SIMPLE_VALUE' in dir(custom_conf))
-        self.assertFalse('TESTS_SIMPLE_VALUE' in custom_conf.__members__)
 
     def test_custom_holder(self):
         CustomHolderConf()

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,13 @@ usedevelop = True
 minversion = 1.8
 envlist =
     flake8-py27,
-    flake8-py33,
-    py{26,27}-dj14,
-    py{27,32,33,34}-dj{17,18},
+    flake8-py34,
+    py{27,32,33,34}-dj18,
     py{27,34,35}-dj19,
     py{27,34,35}-dj110
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3
@@ -25,14 +23,9 @@ setenv =
     DJANGO_SETTINGS_MODULE=tests.test_settings
 deps =
     flake8
-	py{26,27,33,34,35,pypy}: coverage
+	py{27,33,34,35,pypy}: coverage
 	py32: coverage==3.7.1 # latest coverage support py3.2
     django-discover-runner
-    dj13: https://github.com/django/django/archive/stable/1.3.x.zip#egg=django
-    dj14: https://github.com/django/django/archive/stable/1.4.x.zip#egg=django
-    dj15: https://github.com/django/django/archive/stable/1.5.x.zip#egg=django
-    dj16: https://github.com/django/django/archive/stable/1.6.x.zip#egg=django
-    dj17: https://github.com/django/django/archive/stable/1.7.x.zip#egg=django
     dj18: https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
     dj19: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
     dj110: https://github.com/django/django/archive/master.tar.gz#egg=django
@@ -45,7 +38,7 @@ commands =
 commands = flake8 appconf
 deps = flake8
 
-[testenv:flake8-py33]
+[testenv:flake8-py34]
 commands = flake8 appconf
 deps = flake8
 


### PR DESCRIPTION
* Drop EOL Django versions from Travis
* Remove py35-dj19 from allow_failures
* Get Python 3.5 tests working on Travis
* Remove Python < 2.6 `__members__` support
* Add tests checking `override_settings` compat. ref #29 and #30.