### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,7 +222,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/v2.7.2/', None),
-    'django': ('http://django.readthedocs.org/en/latest/', None),
-    'celery': ('http://celery.readthedocs.org/en/latest/', None),
+    'python': ('https://python.readthedocs.io/en/v2.7.2/', None),
+    'django': ('https://django.readthedocs.io/en/latest/', None),
+    'celery': ('https://celery.readthedocs.io/en/latest/', None),
 }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author='Jannis Leidel',
     author_email='jannis@leidel.info',
     license='BSD',
-    url='http://django-appconf.readthedocs.org/',
+    url='https://django-appconf.readthedocs.io/',
     packages=['appconf'],
     install_requires=[],
     classifiers=[


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
