### PR TITLE
Migrate from django.utils.six to six

### DIFF
--- a/appconf/base.py
+++ b/appconf/base.py
@@ -1,7 +1,8 @@
 import sys
 
+import six
+
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 
 from .utils import import_attribute
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license='BSD',
     url='https://django-appconf.readthedocs.io/',
     packages=['appconf'],
-    install_requires=['django'],
+    install_requires=['django', 'six'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Django #27753 has dropped six support

https://code.djangoproject.com/ticket/27753
https://github.com/django/django/commit/41384812efe209c8295a50d78b45e0ffb2992436