### PR TITLE
Drop Python 3.5 support for Django master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-dj21
 
-    - python: 3.5
-      env: TOXENV=py35-djmaster
-
     - python: 3.6
       env: TOXENV=py36-dj111
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py{27,34,35,36,37}-dj111,
     py{34,35,36,37}-dj20,
     py{35,36,37}-dj21,
-    py{35,36,37}-djmaster
+    py{36,37}-djmaster
 
 [testenv]
 basepython =


### PR DESCRIPTION
The new Django master and version 2.2 are dropping support for Python 3.5
and thus having the old versions in the test matrix is redundant.