### PR TITLE
Improve AppConf.__dir__

### DIFF
--- a/appconf/base.py
+++ b/appconf/base.py
@@ -116,7 +116,10 @@ class AppConf(six.with_metaclass(AppConfMetaClass)):
             setattr(self, name, value)
 
     def __dir__(self):
-        return sorted(set(self._meta.names.keys()))
+        super_dir = super(AppConf, self).__dir__()
+        if self._meta.proxy:
+            return sorted(set(super_dir + dir(self._meta.holder)))
+        return super_dir
 
     # For instance access..
     @property

--- a/appconf/base.py
+++ b/appconf/base.py
@@ -116,10 +116,10 @@ class AppConf(six.with_metaclass(AppConfMetaClass)):
             setattr(self, name, value)
 
     def __dir__(self):
-        super_dir = super(AppConf, self).__dir__()
-        if self._meta.proxy:
-            return sorted(set(super_dir + dir(self._meta.holder)))
-        return super_dir
+        from_dict = list(vars(self))
+        from_type = dir(type(self))
+        extras = dir(self._meta.holder) if self._meta.proxy else []
+        return sorted(set(from_dict + from_type + extras))
 
     # For instance access..
     @property

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.0 (unreleased)
+------------------
+
+* Improve the ``dir`` output of ``AppConf`` objects.
+
 1.0.4 (unreleased)
 -----------------
 


### PR DESCRIPTION
The custom `__dir__` leaves out some useful attributes. These include values passed to `AppConf`, attributes of the holder if `AppConf` is a proxy, the `configure_*` and `configure` methods, and `configured_data`.

Here's an example that showcases the above:
```py
from types import SimpleNamespace
from appconf import AppConf

holder = SimpleNamespace(DEFAULT_TEST=1)

class TestConf(AppConf):
    TEST1 = 'test'

    def configure_test1(self, value):
        return 1

    def configure(self):
        test1 = self.configured_data['TEST1']
        default = self.DEFAULT_TEST
        self.configured_data['TEST2'] = test1 + default
        return self.configured_data

    class Meta:
        prefix = 'prefix'
        holder = '__main__.holder'
        proxy = True

conf = TestConf(TEST3=3)
print(dir(conf))
```

Ideally this would print `['DEFAULT_TEST', 'Meta', 'PREFIX_TEST1', 'PREFIX_TEST2', 'PREFIX_TEST3', 'TEST1', 'TEST2', 'TEST3', '_meta', 'configure', 'configure_test1', 'configured_data']`, however it currently only prints `['TEST1']`.

This PR takes the easy route and uses the default `__dir__`, supplementing it with the holder's `__dir__` if the object is a proxy. Unfortunately that means some dunder methods show up. However, that makes it more similar to the `__dir__` of Django's settings (and models?).