### PR TITLE
Fix being able to set some non-upper attributes on the holder

### DIFF
--- a/appconf/base.py
+++ b/appconf/base.py
@@ -130,7 +130,7 @@ class AppConf(six.with_metaclass(AppConfMetaClass)):
                              (name, self._meta.holder_path))
 
     def __setattr__(self, name, value):
-        if name == name.upper():
+        if name.isupper():
             setattr(self._meta.holder,
                     self._meta.prefixed_name(name), value)
         object.__setattr__(self, name, value)

--- a/appconf/base.py
+++ b/appconf/base.py
@@ -133,7 +133,7 @@ class AppConf(six.with_metaclass(AppConfMetaClass)):
         if name.isupper():
             setattr(self._meta.holder,
                     self._meta.prefixed_name(name), value)
-        object.__setattr__(self, name, value)
+        super(AppConf, self).__setattr__(name, value)
 
     def configure(self):
         """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.0 (unreleased)
+------------------
+
+* Fix being able to set some non-upper attributes on the holder
+
 1.0.4 (unreleased)
 -----------------
 


### PR DESCRIPTION
Django 3 explicitly disallows non-upper settings via a `str.isupper()` check. This is slightly different from the existing `str == str.upper()` check. While the former checks if there aren't any lowercase (or titlecase) characters and that there's at least an uppercase character, the latter checks if there aren't any characters that can be uppercased.

Here's a contrived example that breaks on Django 3 (I forgot to update `settings.__setattr__`...):
```py
from types import SimpleNamespace
from appconf import AppConf
from django.conf import settings

holder = SimpleNamespace()
settings.configure(holder)

class TestConf(AppConf):
    class Meta:
        prefix = '123'
        holder = '__main__.holder'

conf = TestConf()
setattr(conf, '456', 123456)
print(getattr(settings, '123_456'))
```

I added it to 1.1.0 since it would needlessly break code on Django <3, and the code on Django 3+ would be broken anyway.