### PR TITLE
Specify package is Python 3 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3 :: Only',
         'Topic :: Utilities',
     ],
     project_urls={


### PR DESCRIPTION
The presence of the generic `Programming Language :: Python` classifier appears to cause pip in Python 2.7 to still install new releases of this package, even though support for Python 2 was removed from this package in the current release. Removing the generic "Python" classifier should prevent this issue, by reading between the lines of [the Python Packaging tutorial](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py) ("In this case, the package is only compatible with Python 3").

Just to be certain, this also adds the `Programming Language :: Python :: 3 :: Only` classifier.