### PR TITLE
Recursively excluding __pycache__

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include AUTHORS
 recursive-include docs *
 recursive-include tests *
+recursive-exclude */__pycache__ *


### PR DESCRIPTION
MANIFEST.in:
Recursively exclude __pycache__ directories.
They break reproducibility and are test/build artifacts of the
build/test/release machine, which should never end up in a sdist.

Closes #72