### PR TITLE
Only test against supported Python & Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,18 @@ matrix:
     - python: 3.8
       env: TOXENV=py38-djmaster
 
+    - python: 3.9
+      env: TOXENV=py39-dj22
+
+    - python: 3.9
+      env: TOXENV=py39-dj31
+
+    - python: 3.9
+      env: TOXENV=py39-dj32
+
+    - python: 3.9
+      env: TOXENV=py39-djmaster
+
 install:
   - pip install tox codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,68 +10,38 @@ matrix:
     - env: TOXENV=py38-djmaster
   include:
     # Python version is just for the look on travis.
-    - python: 3.5
-      env: TOXENV=py35-dj111
-
-    - python: 3.5
-      env: TOXENV=py35-dj20
-
-    - python: 3.5
-      env: TOXENV=py35-dj21
-
-    - python: 3.5
-      env: TOXENV=py35-dj22
-
-    - python: 3.6
-      env: TOXENV=py36-dj111
-
-    - python: 3.6
-      env: TOXENV=py36-dj20
-
-    - python: 3.6
-      env: TOXENV=py36-dj21
-
     - python: 3.6
       env: TOXENV=py36-dj22
 
     - python: 3.6
-      env: TOXENV=py36-dj30
+      env: TOXENV=py36-dj31
+
+    - python: 3.6
+      env: TOXENV=py36-dj32
 
     - python: 3.6
       env: TOXENV=py36-djmaster
 
     - python: 3.7
-      env: TOXENV=py37-dj111
-
-    - python: 3.7
-      env: TOXENV=py37-dj20
-
-    - python: 3.7
-      env: TOXENV=py37-dj21
-
-    - python: 3.7
       env: TOXENV=py37-dj22
 
     - python: 3.7
-      env: TOXENV=py37-dj30
+      env: TOXENV=py37-dj31
+
+    - python: 3.7
+      env: TOXENV=py37-dj32
 
     - python: 3.7
       env: TOXENV=py37-djmaster
 
     - python: 3.8
-      env: TOXENV=py38-dj111
-
-    - python: 3.8
-      env: TOXENV=py38-dj20
-
-    - python: 3.8
-      env: TOXENV=py38-dj21
-
-    - python: 3.8
       env: TOXENV=py38-dj22
 
     - python: 3.8
-      env: TOXENV=py38-dj30
+      env: TOXENV=py38-dj31
+
+    - python: 3.8
+      env: TOXENV=py38-dj32
 
     - python: 3.8
       env: TOXENV=py38-djmaster

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
-    djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
+    djmaster: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =
     coverage run {envbindir}/django-admin.py test -v2 {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ usedevelop = True
 minversion = 1.11
 envlist =
     flake8-py37,
-    py{35,36,37,38}-dj{111,20,21,22},
-    py{36,37,38}-dj{30,master}
+    py{36,37,38}-dj{22,31,32,master},
 
 [testenv]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
@@ -19,13 +17,11 @@ setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE=tests.test_settings
 deps =
-	py{35,36,37,38,pypy}: coverage
+	py{36,37,38,pypy}: coverage
     django-discover-runner
-    dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
-    dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
     djmaster: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ usedevelop = True
 minversion = 1.11
 envlist =
     flake8-py37,
-    py{36,37,38}-dj{22,31,32,master},
+    py{36,37,38,39}-dj{22,31,32,master},
 
 [testenv]
 basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy: pypy
 usedevelop = true
 setenv =


### PR DESCRIPTION
Supported versions of Django are [currently][1] 2.2, 3.1 and 3.2. Python 3.5 is now [EOL][2]. This PR updates the tox and Travis configs to only test supported Python and Django versions. It also adds testing for Python 3.9.

[1]: https://www.djangoproject.com/download/
[2]: https://endoflife.date/python
