### PR TITLE
Update version number and release notes for 1.0.5 release.

### DIFF
--- a/appconf/__init__.py
+++ b/appconf/__init__.py
@@ -1,3 +1,3 @@
 from .base import AppConf  # noqa
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.0.5 (2021-09-24)
+------------------
+
+* Adds testing against latest non-EOL Python and Django versions and updates
+  package metadata accordingly.
+
 1.0.4 (2020-04-01)
 ------------------
 


### PR DESCRIPTION
Closes #83

Pending https://github.com/pypa/trove-classifiers/pull/78