### PR TITLE
Add support for Django 5.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     flake8-py311,
     py{37,38,39,310}-dj32
     py{38,39,310,311}-dj{40,41,42}
-    py{310,311,312}-dj{50,main}
+    py{310,311,312}-dj{50,51,main}
 
 [testenv]
 usedevelop = true
@@ -18,6 +18,7 @@ deps =
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2a1,<4.3
 	dj50: Django>=5.0b1,<5.1
+    dj51: Django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz#egg=django
 
 commands =


### PR DESCRIPTION
Django 5.1 has been just [released](https://docs.djangoproject.com/en/5.1/releases/5.1/).

This updates `setup.py` and tests compatibility via extra tox environments.