### PR TITLE
Update readme badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ django-appconf
     :alt: Build Status
     :target: https://github.com/django-compressor/django-appconf/actions/workflows/tests.yml
 
+.. image:: https://badge.fury.io/py/django-appconf.svg
+    :alt: PyPI version
+    :target: https://pypi.org/project/django-appconf/
+
 A helper class for handling configuration defaults of packaged Django
 apps gracefully.
 

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ django-appconf
     :alt: Code Coverage
     :target: http://codecov.io/github/django-compressor/django-appconf?branch=develop
 
-.. image:: https://secure.travis-ci.org/django-compressor/django-appconf.svg?branch=develop
+.. image:: https://github.com/django-compressor/django-appconf/actions/workflows/tests.yml/badge.svg
     :alt: Build Status
-    :target: http://travis-ci.org/django-compressor/django-appconf
+    :target: https://github.com/django-compressor/django-appconf/actions/workflows/tests.yml
 
 A helper class for handling configuration defaults of packaged Django
 apps gracefully.

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,6 @@
 django-appconf
 ==============
 
-.. image:: http://codecov.io/github/django-compressor/django-appconf/coverage.svg?branch=develop
-    :alt: Code Coverage
-    :target: http://codecov.io/github/django-compressor/django-appconf?branch=develop
-
 .. image:: https://github.com/django-compressor/django-appconf/actions/workflows/tests.yml/badge.svg
     :alt: Build Status
     :target: https://github.com/django-compressor/django-appconf/actions/workflows/tests.yml


### PR DESCRIPTION
- Replaces old Travis CI badge with a GH actions one
- Adds PyPI project badge

I've left the 404ing Code Coverage one but this can be removed too if needed.